### PR TITLE
Add extension trait and colored method

### DIFF
--- a/src/color_print.rs
+++ b/src/color_print.rs
@@ -5,26 +5,13 @@ use crate::{Color, Span, Styles};
 /// # Examples
 ///
 /// ```
-/// use mc_legacy_formatting::{SpanIter, PrintSpanColored};
-///
-/// let s = "§4This will be dark red §oand italic";
-/// let span_iter = SpanIter::new(s);
-///
-/// span_iter.map(PrintSpanColored::from).for_each(|s| print!("{}", s));
-/// println!();
-///
-/// // Output will look close to what you'd see in Minecraft (ignoring the font difference)
-/// ```
-///
-///
-/// ## Using SpanExt
-///
-/// ```
 /// use mc_legacy_formatting::{SpanExt, Span};
 ///
 /// let s = "§4This will be dark red §oand italic";
-/// s.span_iter(None).map(Span::as_colored).for_each(|s| print!("{}", s));
+/// s.span_iter().map(Span::to_colored).for_each(|s| print!("{}", s));
 /// println!();
+///
+/// // Output will look close to what you'd see in Minecraft (ignoring the font difference)
 /// ```
 pub struct PrintSpanColored<'a>(Span<'a>);
 

--- a/src/color_print.rs
+++ b/src/color_print.rs
@@ -15,6 +15,17 @@ use crate::{Color, Span, Styles};
 ///
 /// // Output will look close to what you'd see in Minecraft (ignoring the font difference)
 /// ```
+///
+///
+/// ## Using SpanExt
+///
+/// ```
+/// use mc_legacy_formatting::{SpanExt, Span};
+///
+/// let s = "§4This will be dark red §oand italic";
+/// s.span_iter(None).map(Span::as_colored).for_each(|s| print!("{}", s));
+/// println!();
+/// ```
 pub struct PrintSpanColored<'a>(Span<'a>);
 
 impl<'a> From<Span<'a>> for PrintSpanColored<'a> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,36 @@ mod color_print;
 #[cfg(feature = "color-print")]
 pub use color_print::PrintSpanColored;
 
+/// An extension trait that adds a method for creating a `SpanIter`
+pub trait SpanExt {
+    /// Produces an `SpanIter` from `&self`, optionally configuring the `start_char`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mc_legacy_formatting::{SpanExt, Span, Color, Styles};
+    ///
+    /// let s = "§4This will be dark red §oand italic";
+    /// let mut span_iter = s.span_iter(None);
+    ///
+    /// assert_eq!(span_iter.next().unwrap(), Span::new_styled("This will be dark red ", Color::DarkRed, Styles::empty()));
+    /// assert_eq!(span_iter.next().unwrap(), Span::new_styled("and italic", Color::DarkRed, Styles::ITALIC));
+    /// assert!(span_iter.next().is_none());
+    /// ```
+    fn span_iter<C>(&self, start_char: C) -> SpanIter
+    where
+        C: Into<Option<char>>;
+}
+
+impl<T: AsRef<str>> SpanExt for T {
+    fn span_iter<C>(&self, start_char: C) -> SpanIter
+    where
+        C: Into<Option<char>>,
+    {
+        SpanIter::new(self.as_ref()).with_start_char(start_char.into().unwrap_or('§'))
+    }
+}
+
 /// An iterator that yields [`Span`][Span]s from an input string.
 ///
 /// # Examples
@@ -105,7 +135,7 @@ impl<'a> SpanIter<'a> {
         }
     }
 
-    /// Set the start character used while parsing.
+    /// Set the start character used while parsing
     ///
     /// # Examples
     ///
@@ -370,6 +400,12 @@ impl<'a> Span<'a> {
             color,
             styles,
         }
+    }
+
+    /// Returns a prinatable colored version of the `Span`
+    #[cfg(feature = "color-print")]
+    pub fn as_colored(self) -> PrintSpanColored<'a> {
+        PrintSpanColored::from(self)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ pub use color_print::PrintSpanColored;
 
 /// An extension trait that adds a method for creating a `SpanIter`
 pub trait SpanExt {
-    /// Produces an `SpanIter` from `&self`, optionally configuring the `start_char`
+    /// Produces a `SpanIter` from `&self`, optionally configuring the `start_char`
     ///
     /// # Examples
     ///
@@ -397,7 +397,7 @@ impl<'a> Span<'a> {
         }
     }
 
-    /// Returns a prinatable colored version of the `Span`
+    /// Returns a printable colored version of the `Span`
     #[cfg(feature = "color-print")]
     pub fn to_colored(self) -> PrintSpanColored<'a> {
         PrintSpanColored::from(self)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,10 @@
 //! Using [`SpanIter`][SpanIter]:
 //!
 //! ```
-//! use mc_legacy_formatting::{SpanIter, Span, Color, Styles};
+//! use mc_legacy_formatting::{SpanExt, Span, Color, Styles};
 //!
 //! let s = "§4This will be dark red §oand italic";
-//! let mut span_iter = SpanIter::new(s);
+//! let mut span_iter = s.span_iter();
 //!
 //! assert_eq!(span_iter.next().unwrap(), Span::new_styled("This will be dark red ", Color::DarkRed, Styles::empty()));
 //! assert_eq!(span_iter.next().unwrap(), Span::new_styled("and italic", Color::DarkRed, Styles::ITALIC));
@@ -29,10 +29,10 @@
 //! With a custom start character:
 //!
 //! ```
-//! use mc_legacy_formatting::{SpanIter, Span, Color, Styles};
+//! use mc_legacy_formatting::{SpanExt, Span, Color, Styles};
 //!
 //! let s = "&6It's a lot easier to type &b& &6than &b§";
-//! let mut span_iter = SpanIter::new(s).with_start_char('&');
+//! let mut span_iter = s.span_iter().with_start_char('&');
 //!
 //! assert_eq!(span_iter.next().unwrap(), Span::new_styled("It's a lot easier to type ", Color::Gold, Styles::empty()));
 //! assert_eq!(span_iter.next().unwrap(), Span::new_styled("& ", Color::Aqua, Styles::empty()));
@@ -72,23 +72,18 @@ pub trait SpanExt {
     /// use mc_legacy_formatting::{SpanExt, Span, Color, Styles};
     ///
     /// let s = "§4This will be dark red §oand italic";
-    /// let mut span_iter = s.span_iter(None);
+    /// let mut span_iter = s.span_iter();
     ///
     /// assert_eq!(span_iter.next().unwrap(), Span::new_styled("This will be dark red ", Color::DarkRed, Styles::empty()));
     /// assert_eq!(span_iter.next().unwrap(), Span::new_styled("and italic", Color::DarkRed, Styles::ITALIC));
     /// assert!(span_iter.next().is_none());
     /// ```
-    fn span_iter<C>(&self, start_char: C) -> SpanIter
-    where
-        C: Into<Option<char>>;
+    fn span_iter(&self) -> SpanIter;
 }
 
 impl<T: AsRef<str>> SpanExt for T {
-    fn span_iter<C>(&self, start_char: C) -> SpanIter
-    where
-        C: Into<Option<char>>,
-    {
-        SpanIter::new(self.as_ref()).with_start_char(start_char.into().unwrap_or('§'))
+    fn span_iter(&self) -> SpanIter {
+        SpanIter::new(self.as_ref())
     }
 }
 
@@ -330,7 +325,7 @@ impl<'a> Iterator for SpanIter<'a> {
 /// Text with an associated color and associated styles.
 ///
 /// `Span` implements `Display` and can be neatly printed.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum Span<'a> {
     /// A styled slice of text
     Styled {
@@ -404,7 +399,7 @@ impl<'a> Span<'a> {
 
     /// Returns a prinatable colored version of the `Span`
     #[cfg(feature = "color-print")]
-    pub fn as_colored(self) -> PrintSpanColored<'a> {
+    pub fn to_colored(self) -> PrintSpanColored<'a> {
         PrintSpanColored::from(self)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ pub use color_print::PrintSpanColored;
 
 /// An extension trait that adds a method for creating a `SpanIter`
 pub trait SpanExt {
-    /// Produces a `SpanIter` from `&self`, optionally configuring the `start_char`
+    /// Produces a `SpanIter` from `&self`
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Adds an extension trait for `T: AsRef<str>` making it easier to create a `SpanIter` from a string like type. I've also added a feature gated method on `Span` to make it easier to get a `PrintSpanColored`.

Overall these changes result in the following:
```rust
let s = "&1&e&d&lthis will be light purple and bold &o&a&e&a&mand this \
will be green and strikethrough";

for span in s.span_iter().with_start_char('&').map(Span::as_colored) {
    std::print!("{}", span);
}
```

To print above we now need just `Span` and `SpanExt` and it can all be done in a smooth chain.